### PR TITLE
Adds scan-required as an output from job

### DIFF
--- a/samples/sample-codeql-monorepo-pr-workflow.yml
+++ b/samples/sample-codeql-monorepo-pr-workflow.yml
@@ -39,6 +39,7 @@ jobs:
       contents: read
     outputs:
       projects: ${{ steps.changes.outputs.projects }}
+      scan-required: ${{ steps.changes.outputs.scan-required }}
     steps:
       - name: Spot changes to projects
         id: changes


### PR DESCRIPTION
Fixes skipped job issue: 

![image](https://github.com/user-attachments/assets/27434f07-e4dd-45b7-8da9-86cf2c224667)
