### PR TITLE
Add additional csharp filters

### DIFF
--- a/changes/build-filters.js
+++ b/changes/build-filters.js
@@ -19,7 +19,7 @@ function run(github, context, core) {
   // which filenames to include in the analysis if they are changed, per language
   // TODO: make this configurable (adding new globs) using a file in the repo
   const globs = {
-    csharp: ["**/*.cs", "**/*.csproj", "**/*.sln"],
+    csharp: ["**/*.aspx", "**/*.cs", "**/*.cshtml", "**/*.csproj",   "**/packages.config",  "**/*.razor", "**/*.sln", "**/*.xaml",],
     python: [
       "**/*.py",
       "**/pyproject.toml",


### PR DESCRIPTION
Configuration updates:

* [`changes/build-filters.js`](diffhunk://#diff-082717b3413cdef6023a1eb84583c2d55643a2c7bac07cee7e28ede22e8ecd06L22-R22): Expanded the `csharp` globs to include `**/*.aspx`, `**/*.cshtml`, `**/packages.config`, `**/*.razor`, and `**/*.xaml` file patterns.