### PR TITLE
Annotate sarif fixes

### DIFF
--- a/sarif-project-annotator/sarif-project-annotator.js
+++ b/sarif-project-annotator/sarif-project-annotator.js
@@ -1,4 +1,3 @@
-//const core = require('@actions/core')
 const fs = require('fs').promises
 
 async function run(github, context, core) {
@@ -8,54 +7,12 @@ async function run(github, context, core) {
     const sarifInput = process.env.sarif_file
     const outputFile = process.env.output_file
 
-    //Fix was to pass as env vars - Error: Action failed with error: Error: Input required and not supplied: project
-    // const project = core.getInput('project', { required: true })
-    // const sarifInput = core.getInput('sarif_file', { required: true })
-    // const outputFile = core.getInput('output_file', { required: true })
-
     // Read the input SARIF file  (note this does convert value:1.0 to value:1 )
     const sarifContent = await fs.readFile(sarifInput, 'utf8')
     const sarifData = JSON.parse(sarifContent)
 
-    //#region Support projects.json file (not needed)
-    // const projectsJson = core.getInput('projects-json', { required: true })
-    // // Read the projects JSON file
-    // const projectsContent = await fs.readFile(projectsJson, 'utf8')
-    // const projectsData = JSON.parse(projectsContent)
-
-    // // Create a map of file paths to project names
-    // const projectMap = new Map()
-    // for (const [projectName, projectInfo] of Object.entries(projectsData.csharp.projects)) {
-    //   for (const projectPath of projectInfo.paths) {
-    //     projectMap.set(projectPath, projectName)
-    //   }
-    // }
-    //#endregion
-
     // Process each run in the SARIF file
     for (const sarifRun of sarifData.runs) {
-
-      //#region Per location tags (no tags possible here)
-      //   //File path information is at runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri
-      //   for (const result of sarifRun.results || []) {
-      //     const filePath = result.locations[0].physicalLocation.artifactLocation.uri
-      //     const projectName = [...projectMap.entries()].find(([key, value]) => filePath.includes(key))?.[1]
-
-      //     if (projectName) {
-      //       // Add project as a tag
-      //       if (!result.properties) result.properties = {}
-      //       if (!result.properties.tags) result.properties.tags = []
-
-      //       // Check if a project tag already exists and remove it
-      //       result.properties.tags = result.properties.tags.filter(
-      //         tag => !tag.includes('project/')
-      //       )
-
-      //       // Add the new project tag
-      //       result.properties.tags.push(`project/${projectName}`)
-      //     }
-      //   }
-      //#endregion
 
       // Rule property tag information is at runs[].tool.extensions[].rules[].properties.tags[]
       for (const rule of sarifRun.tool.extensions[0].rules || []) {
@@ -86,6 +43,5 @@ async function run(github, context, core) {
 }
 
 module.exports = async (github, context, core) => {
-  //run(github, context, core).then(() => {});
   await run(github, context, core)
 };

--- a/scan/action.yml
+++ b/scan/action.yml
@@ -87,7 +87,7 @@ runs:
         script: |
           const path = require('node:path')
           const action_path = process.env.GITHUB_ACTION_PATH
-          const script = require(path.join(action_path, 'sarif-project-annotator.js'))
+          const script = require(path.join(action_path, '..', 'sarif-project-annotator', 'sarif-project-annotator.js'))
           return await script(github, context, core)
 
     # Upload the annotated SARIF file to GitHub Code Scanning service

--- a/scan/action.yml
+++ b/scan/action.yml
@@ -49,8 +49,7 @@ runs:
         language: ${{  matrix.project.language }}
         name: ${{  matrix.project.name }}
 
-    # Perform the CodeQL analysis, if we have a CodeQL build
-    # This will upload the SARIF for you
+    # Perform the CodeQL analysis, if we have a CodeQL build (do not upload results - requires further SARIF processing)
     - name: Perform CodeQL Analysis
       id: codeql-analyze
       if: matrix.project.build_mode != 'other'
@@ -61,8 +60,6 @@ runs:
         output: sarif-results
 
     # Parse the db-locations output and get the sarif file name from the analysis
-    # - db-locations ex: {javascript:/home/runner/work/_temp/codeql_databases/javascript}
-    # - sarif-output ex: /home/runner/work/sample-javascript-monorepo/sample-javascript-monorepo/sarif-results
     - name: Set SARIF file name
       id: set-sarif-file-name
       if: matrix.project.build_mode != 'other'
@@ -77,6 +74,7 @@ runs:
           console.log(`SARIF file name: ${sarifFilePath}`);          
           return sarifFilePath;
 
+    # Annotate the SARIF file tags to include the monorepo's current project name
     - name: Annotate CodeQL Alert SARIF with Project tag
       id: annotate-sarif
       uses: actions/github-script@v7
@@ -92,6 +90,7 @@ runs:
           const script = require(path.join(action_path, 'sarif-project-annotator.js'))
           return await script(github, context, core)
 
+    # Upload the annotated SARIF file to GitHub Code Scanning service
     - name: Upload SARIF with project tags
       if: matrix.project.build_mode != 'other'
       uses: github/codeql-action/upload-sarif@v3

--- a/scan/action.yml
+++ b/scan/action.yml
@@ -78,12 +78,19 @@ runs:
           return sarifFilePath;
 
     - name: Annotate CodeQL Alert SARIF with Project tag
-      if: matrix.project.build_mode != 'other'  
-      uses: advanced-security/monorepo-code-scanning-action/sarif-project-annotator@annotate-sarif
-      with:
+      id: annotate-sarif
+      uses: actions/github-script@v7
+      env:
         project: ${{ matrix.project.name }}
         sarif_file: ${{ steps.codeql-analyze.outputs.sarif-output }}/${{ steps.set-sarif-file-name.outputs.result }}
         output_file: ${{ steps.codeql-analyze.outputs.sarif-output }}/${{ matrix.project.name }}-${{ steps.set-sarif-file-name.outputs.result }}
+      with:
+        result-encoding: string
+        script: |
+          const path = require('node:path')
+          const action_path = process.env.GITHUB_ACTION_PATH
+          const script = require(path.join(action_path, 'sarif-project-annotator.js'))
+          return await script(github, context, core)
 
     - name: Upload SARIF with project tags
       if: matrix.project.build_mode != 'other'

--- a/tests/run-annotator-test.js
+++ b/tests/run-annotator-test.js
@@ -12,25 +12,8 @@ async function testSarifProjectAnnotator() {
 
         // Mock process.env variables
         process.env['project'] = 'Project2'
-        //process.env['projects-json'] = 'samples/projects.json'
         process.env['sarif_file'] = 'tests/sarif/sample.sarif'
         process.env['output_file'] = 'tests/sarif/output.sarif'
-
-        // // Mock the inputs
-        // core.getInput = (name) => {
-        //     switch (name) {
-        //         case 'project':
-        //             return 'Project2'
-        //         case 'projects-json':
-        //             return 'samples/projects.json'
-        //         case 'sarif_file':
-        //             return 'tests/sarif/sample.sarif'
-        //         case 'output_file':
-        //             return 'tests/sarif/output.sarif'
-        //         default:
-        //             throw new Error(`Unknown input: ${name}`)
-        //     }
-        // }
 
         // Delete the output file
         try {


### PR DESCRIPTION
Adds some polish to #33 

Key changes include:

### New Feature: Project Annotator

* Added docs for `sarif-project-annotator` action to annotate SARIF files with project tags, which helps in identifying the project of origin in an alert. This includes a detailed example of how to use the action within a workflow. (`README.md`)
* Removed commented-out code and unnecessary sections from the `sarif-project-annotator.js` script to clean up the implementation. (`sarif-project-annotator/sarif-project-annotator.js`) [[1]](diffhunk://#diff-a8814372c13ca69cdc30c463e14f7b840ee327ff4162a1ab4deea6d0d433f693L11-L59) [[2]](diffhunk://#diff-a8814372c13ca69cdc30c463e14f7b840ee327ff4162a1ab4deea6d0d433f693L89)
* Updated the workflow to perform CodeQL analysis without uploading results immediately, allowing for further SARIF processing. (`scan/action.yml`) [[1]](diffhunk://#diff-1721c7ab0ea2c36394fe004570dd75636e2573547874fb32de0e770235a68a4fL52-R52) [[2]](diffhunk://#diff-1721c7ab0ea2c36394fe004570dd75636e2573547874fb32de0e770235a68a4fL64-L65)
* Added steps to annotate the SARIF file with project tags and upload the annotated SARIF file to GitHub Code Scanning service. (`scan/action.yml`)
* Simplified the test setup by removing unnecessary mock input code in the `run-annotator-test.js` file. (`tests/run-annotator-test.js`)