### PR TITLE
Bug: monorepo-code-scanning-action/changes Fix fs import

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For an example of how to use it for PR scans, see [`./samples/sample-codeql-mono
 
 #### Setting project structure
 
-The project structure can either be defined in a JSON file and provided by name in the `project-json` input, or can be parsed out of an MSBuild XML file in the `build-xml` input.
+The project structure can either be defined in a JSON file and provided by name in the `projects-json` input, or can be parsed out of an MSBuild XML file in the `build-xml` input.
 
 It has several purposes - it defines the paths that are watched for changes, and checked out, and also defines CodeQL configuration options.
 

--- a/changes/build-matrix.js
+++ b/changes/build-matrix.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const yaml = require("yaml");
 
 function run(github, context, core) {

--- a/samples/sample-codeql-monorepo-pr-workflow.yml
+++ b/samples/sample-codeql-monorepo-pr-workflow.yml
@@ -59,7 +59,7 @@ jobs:
           build-xml: build-projects.xml
 
           # Alternatively, you can manually set of the project structure with a JSON input file.
-          # project-json: projects.json
+          # projects-json: projects.json
 
           # This takes the form:
           # {

--- a/samples/sample-codeql-monorepo-whole-repo-workflow.yml
+++ b/samples/sample-codeql-monorepo-whole-repo-workflow.yml
@@ -43,7 +43,7 @@ jobs:
           build-xml: build-projects.xml
 
           # Alternatively, you can manually set of the project structure with a JSON input file.
-          # project-json: projects.json
+          # projects-json: projects.json
 
           # This takes the form:
           # {


### PR DESCRIPTION

### JavaScript reference update:

* [`changes/build-matrix.js`](diffhunk://#diff-30fb55edc1c01f2c69fa4d4aa024dc8f7b44848e6f932e3de2a9191b7f9aff03R1): Added the `fs` module import statement.

![image](https://github.com/user-attachments/assets/a2532e3d-1834-40fe-912a-cd3630232909)


### Updates to input parameter names to match the yaml definition:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L83-R83): Changed the input parameter name from `project-json` to `projects-json` to match the correct usage.
* [`samples/sample-codeql-monorepo-pr-workflow.yml`](diffhunk://#diff-e60dc67af1129abbe1157868e64f1e46a60d36438a1d2feb314a03e183880b49L62-R62): Updated the commented input parameter name from `project-json` to `projects-json`.
* [`samples/sample-codeql-monorepo-whole-repo-workflow.yml`](diffhunk://#diff-ea6785f95ec19c680aed8cc43cc4e3fa7ca1c47fb5543a376aba526ceaef59deL46-R46): Updated the commented input parameter name from `project-json` to `projects-json`.
