### PR TITLE
Bug: remove glob set with single item - dorny/paths-filter incompat?

### DIFF
--- a/changes/build-filters.js
+++ b/changes/build-filters.js
@@ -39,7 +39,7 @@ function run(github, context, core) {
       "**/packages.config",
     ],
     python: [
-      "**/*.{py}",
+      "**/*.py",
       "**/pyproject.toml",
       "**/Pipfile{,.lock}",
       "**/requirements.{txt,in}",


### PR DESCRIPTION
This pull request includes a small change to the `changes/build-filters.js` file. The change simplifies the pattern used to match Python files in the `python` array. There appears to be a problem with a glob pattern that has a single item in a set being matched by `dorny/paths-filter`. This PR removes the glob set with a single item to address this incompatibility.