### PR TITLE
Fix: SARIF Republish when >20 analyses are required

### DIFF
--- a/republish-sarif/action.yml
+++ b/republish-sarif/action.yml
@@ -69,6 +69,10 @@ runs:
         done
 
     # Scenario 2: Merged mode - upload SARIF files via GitHub API to the PR target
+    # if we're in merged mode, upload to the PR target
+    # this uses the HEAD SHA of the PR, which is the same as the merge commit SHA
+    # if "require PRs to be up to date before merging" is enabled
+    # otherwise, we have a hard time determining what the commit SHA of the merge commit is
     - name: Upload SARIF files to PR target
       if: github.event.pull_request.merged == true && hashFiles('sarif/*.sarif') != ''
       shell: bash

--- a/republish-sarif/action.yml
+++ b/republish-sarif/action.yml
@@ -25,19 +25,89 @@ runs:
           const script = require(path.join(action_path, 'republish-sarif.js'))
           script(github, context, core)
 
-    # if we're in PR mode, upload to the PR itself
-    - uses: github/codeql-action/upload-sarif@v3
+    # Scenario 1: PR mode - upload SARIF files via GitHub API to the PR itself
+    - name: Upload SARIF files to PR
       if: github.event_name == 'pull_request' && github.event.pull_request.merged != true && hashFiles('sarif/*.sarif') != ''
-      with:
-        sarif_file: sarif
+      shell: bash
+      run: |
+        echo "Uploading SARIF files to PR via GitHub API"
+        
+        # Count SARIF files
+        SARIF_COUNT=$(find sarif -name "*.sarif" | wc -l)
+        echo "Found $SARIF_COUNT SARIF files to upload"
+        
+        # Get repository information
+        REPO_OWNER="${GITHUB_REPOSITORY%/*}"
+        REPO_NAME="${GITHUB_REPOSITORY#*/}"
+        
+        # Upload each SARIF file individually
+        for SARIF_FILE in sarif/*.sarif; do
+          echo "Processing $SARIF_FILE"
+          
+          # Compress and base64 encode the SARIF file
+          ENCODED_SARIF=$(gzip -c "$SARIF_FILE" | base64 -w0)
+          
+          echo "Uploading $(basename "$SARIF_FILE") to PR"
+          
+          # Upload to PR
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/$REPO_OWNER/$REPO_NAME/code-scanning/sarifs \
+            -f "ref=refs/pull/${{ github.event.pull_request.number }}/merge" \
+            -f "sarif=$ENCODED_SARIF"
+          
+          if [ $? -eq 0 ]; then
+            echo "✓ Successfully uploaded $(basename "$SARIF_FILE")"
+          else
+            echo "✗ Failed to upload $(basename "$SARIF_FILE")"
+          fi
+          
+          # Add a small delay between uploads
+          sleep 1
+        done
 
-    # if we're in merged mode, upload to the PR target
-    # this uses the HEAD SHA of the PR, which is the same as the merge commit SHA
-    # if "require PRs to be up to date before merging" is enabled
-    # otherwise, we have a hard time determining what the commit SHA of the merge commit is
-    - uses: github/codeql-action/upload-sarif@v3
+    # Scenario 2: Merged mode - upload SARIF files via GitHub API to the PR target
+    - name: Upload SARIF files to PR target
       if: github.event.pull_request.merged == true && hashFiles('sarif/*.sarif') != ''
-      with:
-        sarif_file: sarif
-        ref: ${{ 'refs/heads/' }}${{ github.event.pull_request.base.ref }}
-        sha: ${{ github.event.pull_request.head.sha }}
+      shell: bash
+      run: |
+        echo "Uploading SARIF files to PR target via GitHub API"
+        
+        # Count SARIF files
+        SARIF_COUNT=$(find sarif -name "*.sarif" | wc -l)
+        echo "Found $SARIF_COUNT SARIF files to upload"
+        
+        # Get repository information
+        REPO_OWNER="${GITHUB_REPOSITORY%/*}"
+        REPO_NAME="${GITHUB_REPOSITORY#*/}"
+        
+        # Upload each SARIF file individually
+        for SARIF_FILE in sarif/*.sarif; do
+          echo "Processing $SARIF_FILE"
+          
+          # Compress and base64 encode the SARIF file
+          ENCODED_SARIF=$(gzip -c "$SARIF_FILE" | base64 -w0)
+          
+          echo "Uploading $(basename "$SARIF_FILE") to target branch"
+          
+          # Upload to PR target
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/$REPO_OWNER/$REPO_NAME/code-scanning/sarifs \
+            -f "commit_sha=${{ github.event.pull_request.head.sha }}" \
+            -f "ref=refs/heads/${{ github.event.pull_request.base.ref }}" \
+            -f "sarif=$ENCODED_SARIF"
+          
+          if [ $? -eq 0 ]; then
+            echo "✓ Successfully uploaded $(basename "$SARIF_FILE")"
+          else
+            echo "✗ Failed to upload $(basename "$SARIF_FILE")"
+          fi
+          
+          # Add a small delay between uploads
+          sleep 1
+        done

--- a/republish-sarif/action.yml
+++ b/republish-sarif/action.yml
@@ -51,14 +51,14 @@ runs:
           
           echo "Uploading $(basename "$SARIF_FILE") to PR"
           
-          # Upload to PR
+          # Upload to PR - Using GITHUB_SHA which is the merge commit for PRs
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/$REPO_OWNER/$REPO_NAME/code-scanning/sarifs \
             -f "ref=refs/pull/${{ github.event.pull_request.number }}/merge" \
-            -f "commit_sha=${{ github.event.pull_request.head.sha }}" \
+            -f "commit_sha=${{ github.sha }}" \
             -f "sarif=$ENCODED_SARIF"
           
           if [ $? -eq 0 ]; then

--- a/republish-sarif/action.yml
+++ b/republish-sarif/action.yml
@@ -29,6 +29,8 @@ runs:
     - name: Upload SARIF files to PR
       if: github.event_name == 'pull_request' && github.event.pull_request.merged != true && hashFiles('sarif/*.sarif') != ''
       shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         echo "Uploading SARIF files to PR via GitHub API"
         
@@ -76,6 +78,8 @@ runs:
     - name: Upload SARIF files to PR target
       if: github.event.pull_request.merged == true && hashFiles('sarif/*.sarif') != ''
       shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         echo "Uploading SARIF files to PR target via GitHub API"
         

--- a/republish-sarif/action.yml
+++ b/republish-sarif/action.yml
@@ -58,6 +58,7 @@ runs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/$REPO_OWNER/$REPO_NAME/code-scanning/sarifs \
             -f "ref=refs/pull/${{ github.event.pull_request.number }}/merge" \
+            -f "commit_sha=${{ github.event.pull_request.head.sha }}" \
             -f "sarif=$ENCODED_SARIF"
           
           if [ $? -eq 0 ]; then

--- a/republish-sarif/republish-sarif.js
+++ b/republish-sarif/republish-sarif.js
@@ -84,84 +84,23 @@ async function run(github, context, core) {
     }
   }
 
-  // Create an array of promises for each download operation
-  const downloadPromises = analysesToDownload.map(async (analysis) => {
+  analysesToDownload.forEach(async (analysis) => {
     if (analysis) {
-      try {
-        const sarif = await github.rest.codeScanning.getAnalysis({
-          owner: context.repo.owner,
-          repo: context.repo.repo,
-          analysis_id: analysis.id,
-          headers: {
-            Accept: "application/sarif+json",
-          },
-        });
-        
-        fs.writeFileSync(
-          `sarif/${escapeForFilename(analysis.category)}.sarif`,
-          JSON.stringify(sarif.data)
-        );
-        core.info(`Downloaded SARIF for ${analysis.category}`);
-      } catch (error) {
-        core.error(`Failed to download SARIF for ${analysis.category}: ${error}`);
-      }
+      const sarif = await github.rest.codeScanning.getAnalysis({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        analysis_id: analysis.id,
+        headers: {
+          Accept: "application/sarif+json",
+        },
+      });
+      fs.writeFileSync(
+        `sarif/${escapeForFilename(analysis.category)}.sarif`,
+        JSON.stringify(sarif.data)
+      );
+      core.info(`Downloaded SARIF for ${analysis.category}`);
     }
   });
-
-  // Wait for all downloads to complete
-  await Promise.all(downloadPromises);
-  
-  // Count the SARIF files in the directory
-  const sarifFiles = fs.readdirSync("sarif").filter(file => file.endsWith(".sarif"));
-  const sarifFilesCount = sarifFiles.length;
-  
-  core.info(`Found ${sarifFilesCount} SARIF files in the directory`);
-
-  // If there are more than 20 SARIF files, add a placeholder file to prevent the codeql-action from combining them
-  if (sarifFilesCount > 20) {
-    core.info(`Adding placeholder SARIF file to prevent combining of ${sarifFilesCount} SARIF files`);
-    addPlaceholderSarifFile();
-    core.info("Added placeholder SARIF file to prevent combining of SARIF files");
-  }
-}
-
-/**
- * Adds a placeholder SARIF file with a non-CodeQL driver name to prevent combining of SARIF files.
- * 
- * Without this, if more than 20 SARIF files are uploaded at once, the following error occurs:
- * "Error: Code Scanning could not process the submitted SARIF file:
- * rejecting SARIF, as there are more runs than allowed (30 > 20)"
- * 
- * The codeql-action attempts to combine SARIF files only when all files are produced by CodeQL.
- * By adding a non-CodeQL SARIF file, we prevent this combination, allowing more than 20 files
- * to be processed individually without hitting the limit.
- */
-function addPlaceholderSarifFile() {
-  // Create a minimal SARIF file with a non-CodeQL driver name
-  const placeholderSarif = {
-    version: "2.1.0",
-    $schema: "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
-    runs: [
-      {
-        tool: {
-          driver: {
-            name: "CodeQL-PREVENT-COMBINED-SARIF",
-            version: "1.0.0",
-            informationUri: "https://github.com/advanced-security/monorepo-code-scanning-action"
-          }
-        },
-        results: [],
-        properties: {
-          comment: "This is a placeholder SARIF file to prevent the codeql-action from combining more than 20 SARIF files into a single upload, which would cause failures."
-        }
-      }
-    ]
-  };
-  
-  fs.writeFileSync(
-    "sarif/placeholder-prevent-combine.sarif",
-    JSON.stringify(placeholderSarif)
-  );
 }
 
 function escapeForFilename(category) {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/15fb1f9c-e3ca-4c10-9733-6dc1cd28234d)

# Fix for SARIF upload failure when handling more than 20 files

## Issue
When republishing SARIF files from the `republish-sarif` action, uploads fail with an error if there are more than 20 SARIF files in a single upload. The error message is:

```
Error: Code Scanning could not process the submitted SARIF file: rejecting SARIF, as there are more runs than allowed (30 > 20)
```


This occurs because GitHub Code Scanning API has a limit of 20 runs per SARIF upload.

## Solution

Since the `codeql-action/upload-sarif` will always combine SARIF files, and the [limit for runs in a SARIF is 20](https://docs.github.com/en/rest/code-scanning/code-scanning?apiVersion=2022-11-28#upload-an-analysis-as-sarif-data) - we need to abandon this.

New republish sarif implementation will loop through the `sarif` folder and invoke the GitHub API to perform the upload via POST to `/repos/{owner}/{repo}/code-scanning/sarifs`.


## Fixes
 
 - Fixes bug where republish-sarif.js was not implementing pagination for retrieving prior analyses (capped at 30).

