### PR TITLE
Add default paths to ignore for various languages in build matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ If you pass a global `queries` input, as a comma separated list of strings, it a
 
 Similarly, you can pass in a global `config` or `config-file` input, which use the same format as  [documented here](https://docs.github.com/en/enterprise-cloud@latest/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#using-a-custom-configuration-file) and [here](https://docs.github.com/en/enterprise-cloud@latest/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#specifying-configuration-details-using-the-config-input). This _cannot_ currently be set at the language or project level, only globally.
 
-The effective config used is a combination of the inputs created from the paths of the project, and any queries set in the separate `queries` input to this Action, overlaid with the content of the `config` or `config-file` inputs.
+The effective config used is a combination of the inputs created from the `paths` of the project, and any queries set in the separate `queries` input to this Action, overlaid with the content of the `config` or `config-file` inputs. The `paths-ignore` will be used if passed in from the config input, otherwise a set of opinionated predetermined paths to ignore will be applied.
 
 ### Whole repo scanning
 


### PR DESCRIPTION
When applying a `paths` filter (as is done by this action), the `paths-ignore` defaults from the CodeQL extractors are NOT utilized. This will likely lead to unwanted detections and decreased performance.  This PR aims to pull in some `opinionated` defaults to continue the journey for improved monorepo scanning.

Primary motivation for this PR was discovered during a performance evaluation 
- Finding that [Ignored the default CodeQL behavior](https://github.com/github/codeql/blob/877118fb3b4c6ad2cdd1bef79e31cf731312ec0b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java#L413-L415) and is extracting `.min.js` files:
```
 [2025-04-11 14:37:52] [build-stdout] Done extracting /home/runner/work/sample-javascript-monorepo/sample-javascript-monorepo/packages/babel-cli/src/babel/sample.min.js (3 ms)
```


Changes to `build-matrix.js` (used by the `changes` and `whole-repo` action):
* Enhancements to default path ignore patterns:
  * [`changes/build-matrix.js`](diffhunk://#diff-30fb55edc1c01f2c69fa4d4aa024dc8f7b44848e6f932e3de2a9191b7f9aff03R10-R166): Added default path ignore patterns for JavaScript/TypeScript, Java/Kotlin, Python, C#, Ruby, and C/C++ to improve the handling of unnecessary files during scans.
* Application of default path ignore patterns:
  * [`changes/build-matrix.js`](diffhunk://#diff-30fb55edc1c01f2c69fa4d4aa024dc8f7b44848e6f932e3de2a9191b7f9aff03R326-R333): Implemented logic to apply default path ignore patterns if not explicitly provided in the project configuration. A warning is issued for languages with `build-mode: none` if no path ignore patterns are set.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L167-R167): Updated the documentation to reflect the use of default path ignore patterns if not passed in the config input.