### PR TITLE
Avoid using diff informed queries

### DIFF
--- a/scan/action.yml
+++ b/scan/action.yml
@@ -13,6 +13,11 @@ runs:
           .github/workflows/**/*
         sparse-checkout-cone-mode: false
 
+    - name: Set scan to non-diff-informed
+      run: |
+        echo "CODEQL_ACTION_DIFF_INFORMED_QUERIES=false" >> $GITHUB_ENV
+      shell: bash
+
     # Initializes CodeQL for scanning, if required
     - name: Initialize CodeQL (build mode none/auto)
       if: matrix.project.build_mode == 'none' || matrix.project.build_mode == 'auto'


### PR DESCRIPTION
Diff informed queries, an upcoming CodeQL feature, provide a partial scan of a PR that isn't compatible with republishing SARIF from the PR to the target branch.

Before some required future work, this PR changes to use the legacy CodeQL behaviour.

## Future work

The future work will trigger a full scan of the changed project on merge, so allowing a full account of the alerts on the target branch to be seen without having to do a full scan of the entire monorepo on each PR merge, and we will deprecate republishing the PR SARIF on merge.